### PR TITLE
Add ingredient filter to draft board

### DIFF
--- a/fantasy_brewing_draft_app.py
+++ b/fantasy_brewing_draft_app.py
@@ -23,6 +23,9 @@ if st.sidebar.button("Reset draft"):
 st.sidebar.metric("My picks", len(my_picks))
 st.sidebar.metric("Total drafted", len(drafted))
 
+# Quick ingredient name filter
+filter_text = st.text_input("Filter ingredients", "")
+
 # Build long list of available ingredients by category
 base_aliases = ["Base Malt", "Base Malts", "Base Malts and Extracts"]
 hop_aliases = ["Hop", "Hops"]
@@ -53,6 +56,10 @@ df_long = pd.DataFrame(long_rows).drop_duplicates()
 
 # Remove drafted ingredients
 available_df = df_long[~df_long["Ingredient"].isin(drafted)]
+
+# Apply filter if text provided
+if filter_text:
+    available_df = available_df[available_df["Ingredient"].str.contains(filter_text, case=False)]
 
 # Category summary
 all_categories = ["Base Malt", "Hop", "Yeast", "Adjunct", "Specialty", "Extra"]

--- a/fantasy_brewing_draft_appv2.py
+++ b/fantasy_brewing_draft_appv2.py
@@ -312,6 +312,9 @@ with tab1:
     else:
         st.success("Draft complete.")
 
+    # Allow quick text filtering of ingredients
+    filter_text = st.text_input("Filter ingredients", key="draft-filter")
+
     def add_pick(player, ing, cat):
         overall = len(st.session_state["draft_log"]) + 1
         round_no = ((overall - 1) // int(num_players)) + 1
@@ -355,6 +358,10 @@ with tab1:
 
     # Remove those already drafted
     df_long = df_long[~df_long["Ingredient"].isin(drafted)]
+
+    # Apply text filter if provided
+    if filter_text:
+        df_long = df_long[df_long["Ingredient"].str.contains(filter_text, case=False)]
 
     # Quick availability summary
     avail_summary = df_long.groupby("Category")["Ingredient"].nunique().reindex(all_categories).fillna(0).astype(int)


### PR DESCRIPTION
## Summary
- Add text input for filtering ingredients on the draft board.
- Apply filter to both classic and v2 draft board views.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0f7ec754883328c4642104f1fb8ff