### PR TITLE
Expand style matrix and fix ingredient names

### DIFF
--- a/ingredient_scarcity.json
+++ b/ingredient_scarcity.json
@@ -30,7 +30,7 @@
     "Scarcity Score": 1.0
   },
   {
-    "Ingredient": "Dememera Sugar",
+    "Ingredient": "Demerara Sugar",
     "Style Coverage": 1,
     "Scarcity Score": 1.0
   },
@@ -85,7 +85,7 @@
     "Scarcity Score": 1.0
   },
   {
-    "Ingredient": "Marris Otter",
+    "Ingredient": "Maris Otter",
     "Style Coverage": 1,
     "Scarcity Score": 1.0
   },

--- a/ingredients_2025.csv
+++ b/ingredients_2025.csv
@@ -14,8 +14,8 @@ German Vienna,Ella,"German Ale (WY1007, G02)",Cocoa Nibs/Beans,Carafa II
 Golden Malt Extract,Fuggle,"German Lager (WLP830, WY2124, L13, 34/70)",Coconut,Carafa III
 Golden Promise,Galaxy,"Hefewiezen (WLP300, WY3068, G01)",Coffee (Liquid or Beans),Carafoam
 Light Malt Extract,Hallertau Mittelfrueh,"Hornindal Kveik (WLP521, OYL-091)",Corn Sugar (Dextrose),Carahell
-Marris Otter,Hallertau Tradition,"Kolsch (WLP029, WY2565, G03, K-97)",Coriander,Caramel/Crystal Malt - 10L
-"Munich, Dark",Idaho 7,"London III (WLP013, A38, WY1318)",Dememera Sugar,Caramel/Crystal Malt - 20L
+Maris Otter,Hallertau Tradition,"Kolsch (WLP029, WY2565, G03, K-97)",Coriander,Caramel/Crystal Malt - 10L
+"Munich, Dark",Idaho 7,"London III (WLP013, A38, WY1318)",Demerara Sugar,Caramel/Crystal Malt - 20L
 Munich Malt Extract,Krush (HBC 586),"Lutra Kveik (OYL-071, OYL-071DRY)",Dragon Fruit,Caramel/Crystal Malt - 30L
 "Munich, Light",Kohatu,"Mexican Lager (WLP940, OYL-113, L09)",Grains of Paradise,Caramel/Crystal Malt - 40L
 Pale Malt Extract,Lemondrop,"Munich Lager (WLP838, WY2308, Dry)",Grapefruit Peel,Caramel/Crystal Malt - 60L

--- a/opponent_model.json
+++ b/opponent_model.json
@@ -218,7 +218,7 @@
     },
     {
       "Category": "Malt",
-      "Ingredient": "Marris Otter",
+      "Ingredient": "Maris Otter",
       "Picks": 2,
       "Avg_Slot": 6.0,
       "First_Year": 2023,
@@ -920,7 +920,7 @@
     },
     {
       "Category": "Adjunct",
-      "Ingredient": "Dememera Sugar",
+      "Ingredient": "Demerara Sugar",
       "Picks": 1,
       "Avg_Slot": 5.0,
       "First_Year": 2024,
@@ -1341,7 +1341,7 @@
     },
     {
       "A": "English Ale (WLP002, WY1968, S-04, A09)",
-      "B": "Marris Otter",
+      "B": "Maris Otter",
       "PairCount": 1
     },
     {
@@ -1556,7 +1556,7 @@
     },
     {
       "A": "Galaxy",
-      "B": "Marris Otter",
+      "B": "Maris Otter",
       "PairCount": 1
     },
     {
@@ -1651,7 +1651,7 @@
     },
     {
       "A": "Coffee",
-      "B": "Marris Otter",
+      "B": "Maris Otter",
       "PairCount": 1
     },
     {
@@ -1731,7 +1731,7 @@
     },
     {
       "A": "Citra",
-      "B": "Marris Otter",
+      "B": "Maris Otter",
       "PairCount": 1
     },
     {
@@ -1780,22 +1780,22 @@
       "PairCount": 1
     },
     {
-      "A": "Dememera Sugar",
+      "A": "Demerara Sugar",
       "B": "Pale Malt (2 Row)",
       "PairCount": 1
     },
     {
-      "A": "Dememera Sugar",
+      "A": "Demerara Sugar",
       "B": "Munich Lager (WLP838, WY2308, Dry)",
       "PairCount": 1
     },
     {
-      "A": "Dememera Sugar",
+      "A": "Demerara Sugar",
       "B": "Hallertau Tradition",
       "PairCount": 1
     },
     {
-      "A": "Dememera Sugar",
+      "A": "Demerara Sugar",
       "B": "Extract, Munich",
       "PairCount": 1
     },
@@ -2248,7 +2248,7 @@
     },
     {
       "Yeast": "English Ale (WLP002, WY1968, S-04, A09)",
-      "Malt": "Marris Otter",
+      "Malt": "Maris Otter",
       "Count": 1
     },
     {
@@ -2496,7 +2496,7 @@
       "Count": 1
     },
     {
-      "Malt": "Marris Otter",
+      "Malt": "Maris Otter",
       "Hops": "Galaxy",
       "Count": 1
     }

--- a/style_matrix.json
+++ b/style_matrix.json
@@ -119,10 +119,9 @@
       "Candi Sugar, Dark",
       "Cane (or Beet) Sugar",
       "Corn Sugar (Dextrose)",
-      "Dememera Sugar",
+      "Demerara Sugar",
       "Honey",
       "Lyle's Golden Syrup (Invert Sugar)",
-      "Milk Sugar (Lactose)",
       "Turbinado Sugar"
     ],
     "Specialty": []
@@ -144,7 +143,7 @@
       "Golden Malt Extract",
       "Golden Promise",
       "Light Malt Extract",
-      "Marris Otter",
+      "Maris Otter",
       "Munich Malt Extract",
       "Munich, Dark",
       "Munich, Light",
@@ -355,8 +354,16 @@
     ]
   },
   "Bi\u00e8re de Garde": {
-    "Base Malt": [],
-    "Hop": [],
+    "Base Malt": [
+      "Belgian Pilsner",
+      "Munich, Light",
+      "Munich, Dark"
+    ],
+    "Hop": [
+      "Hallertau Tradition",
+      "Saaz",
+      "Strisselspalt"
+    ],
     "Yeast": [
       "Belgian Ale (WLP570, WY1388)",
       "Belgian Ardennes (WY3522, B45)",
@@ -372,8 +379,14 @@
     "Specialty": []
   },
   "Belgian Dubbel": {
-    "Base Malt": [],
-    "Hop": [],
+    "Base Malt": [
+      "Belgian Pilsner",
+      "Munich, Light"
+    ],
+    "Hop": [
+      "Saaz",
+      "Styrian Goldings"
+    ],
     "Yeast": [
       "Belgian Ale (WLP570, WY1388)",
       "Belgian Ardennes (WY3522, B45)",
@@ -386,11 +399,20 @@
       "Candi Sugar, Dark",
       "Turbinado Sugar"
     ],
-    "Specialty": []
+    "Specialty": [
+      "Chocolate Malt",
+      "Special B"
+    ]
   },
   "Belgian Dark Strong": {
-    "Base Malt": [],
-    "Hop": [],
+    "Base Malt": [
+      "Belgian Pilsner",
+      "Munich, Dark"
+    ],
+    "Hop": [
+      "Saaz",
+      "Styrian Goldings"
+    ],
     "Yeast": [
       "Belgian Ale (WLP570, WY1388)",
       "Belgian Ardennes (WY3522, B45)",
@@ -403,11 +425,20 @@
       "Candi Sugar, Dark",
       "Turbinado Sugar"
     ],
-    "Specialty": []
+    "Specialty": [
+      "Chocolate Malt",
+      "Special B"
+    ]
   },
   "Saison": {
-    "Base Malt": [],
-    "Hop": [],
+    "Base Malt": [
+      "Belgian Pilsner",
+      "White Wheat"
+    ],
+    "Hop": [
+      "Saaz",
+      "Strisselspalt"
+    ],
     "Yeast": [
       "Belgian Ale (WLP570, WY1388)",
       "Belgian Ardennes (WY3522, B45)",
@@ -428,7 +459,11 @@
       "Golden Promise",
       "Maris Otter"
     ],
-    "Hop": [],
+    "Hop": [
+      "Challenger",
+      "East Kent Goldings",
+      "Fuggle"
+    ],
     "Yeast": [
       "Dry English Ale (WLP007, WY1098, A10)",
       "London III (WLP013, A38, WY1318)",
@@ -443,7 +478,11 @@
       "Golden Promise",
       "Maris Otter"
     ],
-    "Hop": [],
+    "Hop": [
+      "Challenger",
+      "East Kent Goldings",
+      "Fuggle"
+    ],
     "Yeast": [
       "Dry English Ale (WLP007, WY1098, A10)",
       "London III (WLP013, A38, WY1318)",
@@ -458,7 +497,11 @@
       "Golden Promise",
       "Maris Otter"
     ],
-    "Hop": [],
+    "Hop": [
+      "Challenger",
+      "East Kent Goldings",
+      "Fuggle"
+    ],
     "Yeast": [
       "Dry English Ale (WLP007, WY1098, A10)",
       "London III (WLP013, A38, WY1318)",
@@ -473,13 +516,21 @@
       "Golden Promise",
       "Maris Otter"
     ],
-    "Hop": [],
+    "Hop": [
+      "Challenger",
+      "East Kent Goldings",
+      "Fuggle"
+    ],
     "Yeast": [
       "Dry English Ale (WLP007, WY1098, A10)",
       "London III (WLP013, A38, WY1318)",
       "Scottish Ale (WLP028, WY1728, A31)"
     ],
     "Adjunct": [],
-    "Specialty": []
+    "Specialty": [
+      "Black Malt",
+      "Chocolate Malt",
+      "Roasted Barley"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Add missing base malt, hop, and specialty entries to several Belgian and British styles for a more complete style matrix.
- Remove lactose from Belgian Blonde/Tripel adjunct list and correct ingredient spellings across data files.

## Testing
- ✅ `python -m json.tool style_matrix.json`
- ✅ `python -m json.tool ingredient_scarcity.json`
- ✅ `python -m json.tool opponent_model.json`
- ✅ `python - <<'PY' import csv ...`
- ⚠️ `python - <<'PY' import draft_core as dc` *(missing pandas)*
- ⚠️ `pip install pandas` *(proxy 403 prevented download)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f4cb279883328404c127cd3b5ce6