### PR TITLE
Refine pick recommendations to emphasize style fit

### DIFF
--- a/draft_core.py
+++ b/draft_core.py
@@ -230,8 +230,9 @@ def next_best_picks(
         need_bonus = cat_need_factor.get(cat, 1.0)
         popularity = float(early_signal.get(ing, 0.0)) if early_signal else 0.0
         bias_factor = ingredient_style_bias(ing, style_matrix, style_bias)
+        # Favor style coverage more heavily than ingredient scarcity
         pick_value = (
-            (style_cov * 1.0 + scarcity * 2.0 + popularity * bias_weight)
+            (style_cov * 2.0 + scarcity * 1.0 + popularity * bias_weight)
             * need_bonus
             * bias_factor
         )

--- a/fantasy_brewing_draft_appv2.py
+++ b/fantasy_brewing_draft_appv2.py
@@ -768,7 +768,8 @@ def next_best_picks(my_picks, drafted, style_matrix, scarcity_df, required, flex
         need_bonus = cat_need_factor.get(cat, 1.0)
         popularity = float(early_signal.get(ing, 0.0))
         bias_factor = ingredient_style_bias(ing, style_matrix, style_bias)
-        pick_value = (style_cov * 1.0 + scarcity * 2.0 + popularity * bias_weight) * need_bonus * bias_factor
+        # Favor style coverage more heavily than ingredient scarcity
+        pick_value = (style_cov * 2.0 + scarcity * 1.0 + popularity * bias_weight) * need_bonus * bias_factor
         rows.append({
             "Ingredient": ing,
             "Category": cat,


### PR DESCRIPTION
## Summary
- Adjust next_best_picks weighting to prioritize style coverage over ingredient scarcity
- Apply the same change in the Streamlit draft app

## Testing
- `python -m py_compile draft_core.py fantasy_brewing_draft_appv2.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2509a8f3083328fe853e8c79fbd52